### PR TITLE
fix(danmu): 修复重叠检测结果返回逻辑

### DIFF
--- a/danmu_diff_main.js
+++ b/danmu_diff_main.js
@@ -351,7 +351,7 @@
 
         // 移除重叠的检测结果，保留较长的敏感词
         removeOverlappingDetections(detectedWords) {
-            if (detectedWords.length <= 1) return detectedWords;
+            if (detectedWords.length <= 1) return [...detectedWords];
             
             // 按开始位置排序
             detectedWords.sort((a, b) => a.startIndex - b.startIndex);


### PR DESCRIPTION
- 修改 removeOverlappingDetections 方法，确保在检测词数量为1时返回新数组，避免直接引用原数组